### PR TITLE
docs: fix electoral mandate descriptions - PeerSelect, RoleByRoles, D…

### DIFF
--- a/documentation/src/content/docs/mandates/electoral/DelegateTokenSelect.mdx
+++ b/documentation/src/content/docs/mandates/electoral/DelegateTokenSelect.mdx
@@ -72,8 +72,7 @@ function handleRequest(...) public view override returns (...)
 
 ### Error Conditions
 
-1.  **Configuration Errors**
-    *   Invalid contract addresses for `VotesToken` or `NomineesContract`.
+This mandate has no explicit error conditions. If invalid contract addresses are provided for `VotesToken` or `NomineesContract`, the transaction will fail at the external call level with a generic EVM error.
 
 ## Current Deployments
 

--- a/documentation/src/content/docs/mandates/electoral/PeerSelect.mdx
+++ b/documentation/src/content/docs/mandates/electoral/PeerSelect.mdx
@@ -3,26 +3,26 @@ title: Peer Select
 description: Guide for using the PeerSelect mandate in the Powers protocol
 ---
 
-PeerSelect is an electoral mandate that allows members of a group to vote on a slate of nominees, directly assigning or revoking roles based on the collective selection.
+PeerSelect is an electoral mandate that allows an authorized caller to select exactly N nominees from a candidate list, fully replacing the current set of role holders with the new selection. It is designed as a one-time-use mandate: after execution, it revokes itself.
 
 ## Overview
 
-This mandate enables a more granular and interactive selection process than `DelegateTokenSelect`. Instead of relying on token weight, it allows authorized callers (usually holding a specific "voter" role via the mandate's permissions) to:
-1.  View the list of current nominees (from a `Nominees` contract).
-2.  Submit a selection (a set of votes) for multiple nominees.
-3.  Directly assign the role to selected nominees who don't have it.
-4.  Directly revoke the role from selected nominees who already have it.
+This mandate allows an authorized caller to:
+1.  View the current list of nominees from a `Nominees` contract.
+2.  Submit a boolean selection array — one entry per nominee.
+3.  Revoke the role from all current holders.
+4.  Assign the role to the selected nominees.
+5.  Revoke the mandate itself, preventing it from being executed again.
 
-This is effectively a "toggle" mechanism where the voter can curate the list of role holders, subject to a maximum cap on total holders.
+This is a full reset mechanism, not a toggle. Every execution replaces the entire set of role holders with the chosen nominees.
 
 ## Configuration
 
 When adopting a PeerSelect instance, the following parameters are required:
 
-1.  `maxRoleHolders` (uint256): The absolute maximum number of accounts that can hold the role at any time. Assignments that would exceed this limit will revert.
-2.  `roleId` (uint256): The role ID to be assigned or revoked.
-3.  `maxVotes` (uint8): The maximum number of nominees a voter can select in a single transaction.
-4.  `NomineesContract` (address): The address of the Nominees helper contract providing the list of candidates.
+1.  `numberToSelect` (uint8): The exact number of nominees that must be selected. The caller must select precisely this many — no more, no fewer.
+2.  `roleId` (uint256): The role ID to be assigned to the selected nominees (and revoked from all current holders).
+3.  `NomineesContract` (address): The address of the Nominees helper contract providing the list of candidates.
 
 ## Usage
 
@@ -30,29 +30,27 @@ When adopting a PeerSelect instance, the following parameters are required:
 
 When calling the mandate, one parameter must be provided:
 
-1.  `selection` (bool[]): An array of booleans corresponding to the list of nominees fetched from the `NomineesContract`.
-    *   `true`: Select this nominee (Assign if they don't have the role, Revoke if they do).
-    *   `false`: Do nothing for this nominee.
+1.  `selection` (bool[]): An array of booleans, one per nominee in the `NomineesContract` list.
+    *   `true`: Select this nominee for the role.
+    *   `false`: Do not select this nominee.
 
-The length of this array must match the current number of nominees.
+The array length must exactly match the current number of nominees, and exactly `numberToSelect` entries must be `true`.
 
 ### Execution Flow
 
 1.  **Validation**
-    *   Verifies that the `selection` array length matches the nominee list.
-    *   Verifies that the number of `true` selections is between 1 and `maxVotes`.
+    *   Verifies that the `selection` array length matches the nominee list length.
+    *   Verifies there are at least `numberToSelect` nominees available.
+    *   Verifies that the number of `true` entries equals exactly `numberToSelect`.
 
-2.  **Processing Selections**
-    *   Iterates through the selections.
-    *   For each selected nominee:
-        *   **If they have the role:** Revokes it.
-        *   **If they don't have the role:** Assigns it (incrementing the holder count).
+2.  **Role Reset**
+    *   Revokes the role from every current role holder.
 
-3.  **Capacity Check**
-    *   If any assignments are made, checks if the new total of role holders would exceed `maxRoleHolders`. If so, reverts.
+3.  **Role Assignment**
+    *   Assigns the role to each selected nominee.
 
-4.  **Execution**
-    *   Batches all `assignRole` and `revokeRole` calls and returns them for execution by the Powers contract.
+4.  **Self-Revocation**
+    *   Revokes the mandate itself (`revokeMandate`), making it impossible to execute again. This ensures PeerSelect is a one-time selection event.
 
 ## Technical Specifications
 
@@ -63,21 +61,22 @@ The length of this array must match the current number of nominees.
 function initializeMandate(...) public override
 ```
 -   Initializes configuration.
--   Fetches the nominee list to generate the input parameter description (UI hint).
+-   Dynamically generates the input parameter list from the current nominee addresses at the time of initialization (one `bool` per nominee).
 
 #### `handleRequest`
 ```solidity
 function handleRequest(...) public view virtual override returns (...)
 ```
--   Implements the toggle logic and validation.
+-   Validates the selection array.
+-   Builds revocation calls for all current role holders.
+-   Builds assignment calls for selected nominees.
+-   Appends a final `revokeMandate` call targeting itself.
 
 ### Error Conditions
 
-1.  **Validation Errors**
-    *   "Invalid selection length.": Input array doesn't match nominee count.
-    *   "Must select at least one nominee."
-    *   "Too many selections. Exceeds maxVotes limit."
-    *   "Too many assignments. Would exceed max role holders."
+*   `"Invalid selection length."` — The `selection` array length does not match the current nominee count.
+*   `"Not enough nominees to fill the seats."` — Fewer nominees exist than `numberToSelect` requires.
+*   `"Must select exactly numberToSelect options."` — The number of `true` entries in the selection does not equal `numberToSelect`.
 
 ## Current Deployments
 

--- a/documentation/src/content/docs/mandates/electoral/RoleByRoles.mdx
+++ b/documentation/src/content/docs/mandates/electoral/RoleByRoles.mdx
@@ -3,23 +3,21 @@ title: RoleByRoles
 description: Guide for using the RoleByRoles mandate in the Powers protocol
 ---
 
-RoleByRoles is an electoral mandate that assigns or revokes a role based on whether an account holds any of a set of prerequisite roles. It provides a mechanism for composing "grouped" roles and automatic role management based on prerequisite role ownership.
+RoleByRoles is an electoral mandate that assigns or revokes a role based on whether an account holds any of a set of prerequisite roles. It is useful for composing "grouped" roles — for example, granting a general contributor role to anyone who holds any of several specific contributor roles.
 
 ## Overview
 
-This mandate provides a mechanism to:
-- Assign a target role to accounts holding prerequisite roles
-- Revoke the target role when prerequisite roles are lost
-- Compose hierarchical role structures
-- Automatically manage role assignments
-- Track role dependencies
+This mandate checks a single account against a list of prerequisite roles and synchronizes a target role accordingly:
+- If the account holds **any** of the prerequisite roles and does **not** yet have the target role → assigns the target role.
+- If the account holds **none** of the prerequisite roles but **does** have the target role → revokes the target role.
+- If no change is needed (already in sync) → returns empty execution data without reverting.
 
 ## Configuration
 
 When adopting a RoleByRoles instance, two parameters must be provided:
 
-1. `newRoleId` (uint256): The role ID to assign/revoke based on prerequisites
-2. `roleIdsNeeded` (uint256[]): Array of prerequisite role IDs
+1. `newRoleId` (uint256): The role ID to assign or revoke based on prerequisites.
+2. `roleIdsNeeded` (uint256[]): Array of prerequisite role IDs. Holding any one of these is sufficient to qualify for the target role.
 
 ## Usage
 
@@ -27,90 +25,41 @@ When adopting a RoleByRoles instance, two parameters must be provided:
 
 When calling the mandate, one parameter must be provided:
 
-1. `account` (address): The account to check and potentially assign/revoke the role for
+1. `account` (address): The account to check and potentially assign/revoke the role for.
 
 ### Execution Flow
 
 1. **Prerequisite Check**
-   - Checks if the account holds any of the prerequisite roles
-   - Verifies current role status for the target role
-   - Determines required action
+   - Checks if the account holds any of the roles in `roleIdsNeeded`.
+   - Checks if the account already holds `newRoleId`.
 
 2. **Role Assignment Logic**
-   - If account has prerequisite roles and doesn't have target role:
-     - Assigns the target role
-   - If account lacks prerequisite roles but has target role:
-     - Revokes the target role
-   - If no change needed:
-     - Returns empty execution data
-
-3. **State Management**
-   - Records role assignment/revocation
-   - Updates role holder lists
-   - Tracks role dependencies
+   - If account has a prerequisite role and does not have the target role → assigns the target role.
+   - If account has no prerequisite roles but has the target role → revokes the target role.
+   - If no change is needed → returns empty execution data (no revert).
 
 ## Technical Specifications
-
-### State Variables
-
-```solidity
-struct Data {
-    uint256 newRoleId;        // Role ID to assign/revoke
-    uint256[] roleIdsNeeded;  // Array of prerequisite role IDs
-}
-
-mapping(bytes32 mandateHash => Data) public data;
-```
 
 ### Functions
 
 #### `initializeMandate`
 ```solidity
-function initializeMandate(
-    uint16 index,
-    string memory nameDescription,
-    bytes memory inputParams,
-    bytes memory config
-) public override
+function initializeMandate(...) public override
 ```
-- Initializes mandate with configuration parameters
-- Sets up target role and prerequisite roles
-- Configures role dependency structure
+- Stores configuration (target role ID and prerequisite role IDs).
+- Sets input parameters to `(address Account)`.
 
 #### `handleRequest`
 ```solidity
-function handleRequest(
-    address caller,
-    address powers,
-    uint16 mandateId,
-    bytes memory mandateCalldata,
-    uint256 nonce
-) public view virtual override returns (
-    uint256 actionId,
-    address[] memory targets,
-    uint256[] memory values,
-    bytes[] memory calldatas
-)
+function handleRequest(...) public view virtual override returns (...)
 ```
-- Processes the role management request
-- Checks prerequisite role ownership
-- Prepares role assignment/revocation call
-- Returns execution data
+- Decodes the target account from calldata.
+- Checks prerequisite role ownership against the Powers contract.
+- Returns an `assignRole` or `revokeRole` call, or empty arrays if no change is needed.
 
 ### Error Conditions
 
-1. **Role Assignment Errors**
-   - "Account already has role"
-   - "Account does not have prerequisite roles"
-
-2. **Role Revocation Errors**
-   - "Account does not have role"
-   - "Account still has prerequisite roles"
-
-3. **Validation Errors**
-   - Invalid role ID
-   - Invalid account address
-   - Zero address account
+This mandate has no explicit reverts for no-op cases. If the account's role status is already in sync, it returns empty execution data and the action completes without any state change.
 
 ## Current Deployments
 
@@ -118,7 +67,7 @@ function handleRequest(
 |-----------|-------------------|----------------------------------------------|
 | 421614    | Arbitrum Sepolia  | 0xa797799EE0C6FA7d9b76eF52e993288a04982267  |
 | 11155420  | Optimism Sepolia  | 0xa797799EE0C6FA7d9b76eF52e993288a04982267  |
-| 11155111  | Ethereum Sepolia  | 0xa797799EE0C6FA7d9b76eF52e993288a04982267  | 
+| 11155111  | Ethereum Sepolia  | 0xa797799EE0C6FA7d9b76eF52e993288a04982267  |
 
 
 


### PR DESCRIPTION
**PeerSelect.mdx — fully rewritten:**

Config: replaced maxRoleHolders/maxVotes → numberToSelect (uint8), roleId, NomineesContract
Overview: replaced "toggle" framing → "full reset" framing
Error messages: replaced 4 fabricated messages → the 3 actual revert strings from the Sol
Added the self-revocation behavior as its own step in the execution flow

**RoleByRoles.mdx — cleaned up:**

Removed the fabricated Data struct and mapping code block
Replaced fabricated error conditions → accurate note that no-op cases return empty arrays, no reverts
Removed the "State Management" bullet points that weren't in the code

**DelegateTokenSelect.mdx — one line:**

Replaced the fabricated error condition with an accurate note that failures come from the EVM, not this contract