### PR TITLE
more visual edits

### DIFF
--- a/documentation/astro.config.mjs
+++ b/documentation/astro.config.mjs
@@ -17,6 +17,9 @@ export default defineConfig({
 				alt: 'Powers Protocol',
 			},
 			customCss: ['./src/styles/custom.css'],
+			components: {
+				ThemeSelect: './src/components/ThemeSelect.astro',
+			},
 			head: [
 				{ tag: 'link', attrs: { rel: 'preload', as: 'font', type: 'font/woff2', href: '/fonts/CormorantGaramond-400-latin.woff2', crossorigin: true } },
 				{ tag: 'link', attrs: { rel: 'preload', as: 'font', type: 'font/otf', href: '/fonts/CommitMono-400-Regular.otf', crossorigin: true } },

--- a/documentation/src/components/ThemeSelect.astro
+++ b/documentation/src/components/ThemeSelect.astro
@@ -1,0 +1,69 @@
+<starlight-theme-toggle>
+	<button
+		aria-label="Toggle light/dark mode"
+		title="Toggle light/dark mode"
+	>
+		<svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter">
+			<circle cx="12" cy="12" r="5"/>
+			<line x1="12" y1="1" x2="12" y2="3"/>
+			<line x1="12" y1="21" x2="12" y2="23"/>
+			<line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+			<line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+			<line x1="1" y1="12" x2="3" y2="12"/>
+			<line x1="21" y1="12" x2="23" y2="12"/>
+			<line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+			<line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+		</svg>
+		<svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter">
+			<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+		</svg>
+	</button>
+</starlight-theme-toggle>
+
+<style>
+	starlight-theme-toggle button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0.4rem;
+		color: var(--sl-color-gray-1);
+	}
+
+	starlight-theme-toggle button:hover {
+		color: var(--sl-color-accent);
+	}
+
+	/* Show sun in dark mode (click to go light), moon in light mode (click to go dark) */
+	:root[data-theme='dark'] .icon-sun  { display: block; }
+	:root[data-theme='dark'] .icon-moon { display: none;  }
+	:root:not([data-theme='dark']) .icon-sun  { display: none;  }
+	:root:not([data-theme='dark']) .icon-moon { display: block; }
+</style>
+
+<script>
+	const storageKey = 'starlight-theme';
+
+	function getTheme(): 'light' | 'dark' {
+		const stored = localStorage.getItem(storageKey);
+		if (stored === 'light' || stored === 'dark') return stored;
+		return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+	}
+
+	function setTheme(theme: 'light' | 'dark') {
+		localStorage.setItem(storageKey, theme);
+		document.documentElement.dataset.theme = theme;
+		StarlightThemeProvider.updatePickers(theme);
+	}
+
+	class StarlightThemeToggle extends HTMLElement {
+		connectedCallback() {
+			this.querySelector('button')?.addEventListener('click', () => {
+				setTheme(getTheme() === 'dark' ? 'light' : 'dark');
+			});
+		}
+	}
+	customElements.define('starlight-theme-toggle', StarlightThemeToggle);
+</script>

--- a/documentation/src/styles/custom.css
+++ b/documentation/src/styles/custom.css
@@ -284,6 +284,11 @@ h1#_top {
   padding: 2rem;
 }
 
+/* Hide empty content panel (e.g. splash/hero pages with no body content) */
+.sl-markdown-content:not(:has(*)) {
+  display: none;
+}
+
 /* Sidebar right border */
 nav.sidebar {
   border-inline-end: 1px solid var(--sl-color-gray-5);


### PR DESCRIPTION
Theme toggle: Replaced Starlight's three-option dropdown (Light / Dark / Auto) with a single icon button that toggles directly between light and dark mode.

Content cleanup: Removed empty bordered panel on the homepage splash template.