### PR TITLE
documentation site visual polish: Commit Mono only, orange accents, s…

### DIFF
--- a/documentation/astro.config.mjs
+++ b/documentation/astro.config.mjs
@@ -21,7 +21,6 @@ export default defineConfig({
 				ThemeSelect: './src/components/ThemeSelect.astro',
 			},
 			head: [
-				{ tag: 'link', attrs: { rel: 'preload', as: 'font', type: 'font/woff2', href: '/fonts/CormorantGaramond-400-latin.woff2', crossorigin: true } },
 				{ tag: 'link', attrs: { rel: 'preload', as: 'font', type: 'font/otf', href: '/fonts/CommitMono-400-Regular.otf', crossorigin: true } },
 				{ tag: 'link', attrs: { rel: 'preload', as: 'font', type: 'font/otf', href: '/fonts/CommitMono-700-Regular.otf', crossorigin: true } },
 				{

--- a/documentation/src/styles/custom.css
+++ b/documentation/src/styles/custom.css
@@ -1,49 +1,3 @@
-/* Cormorant Garamond — self-hosted */
-@font-face {
-  font-family: 'Cormorant Garamond';
-  src: url('/fonts/CormorantGaramond-400-latin.woff2') format('woff2');
-  font-weight: 400;
-  font-style: normal;
-  font-display: block;
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-@font-face {
-  font-family: 'Cormorant Garamond';
-  src: url('/fonts/CormorantGaramond-400-latin-ext.woff2') format('woff2');
-  font-weight: 400;
-  font-style: normal;
-  font-display: block;
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-@font-face {
-  font-family: 'Cormorant Garamond';
-  src: url('/fonts/CormorantGaramond-400-vietnamese.woff2') format('woff2');
-  font-weight: 400;
-  font-style: normal;
-  font-display: block;
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
-}
-
-@font-face {
-  font-family: 'Cormorant Garamond';
-  src: url('/fonts/CormorantGaramond-400-cyrillic.woff2') format('woff2');
-  font-weight: 400;
-  font-style: normal;
-  font-display: block;
-  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-}
-
-@font-face {
-  font-family: 'Cormorant Garamond';
-  src: url('/fonts/CormorantGaramond-400-cyrillic-ext.woff2') format('woff2');
-  font-weight: 400;
-  font-style: normal;
-  font-display: block;
-  unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-}
-
 /* Commit Mono — all text */
 @font-face {
   font-family: 'Commit Mono';
@@ -115,7 +69,7 @@
 
 /* H1 — Cormorant Garamond, 48px */
 .sl-markdown-content h1 {
-  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-family: 'Commit Mono', 'Courier New', monospace;
   font-size: 3rem;
   font-weight: 400;
   line-height: 1.2;
@@ -123,7 +77,7 @@
 
 /* H2 — Cormorant Garamond, 32px */
 .sl-markdown-content h2 {
-  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-family: 'Commit Mono', 'Courier New', monospace;
   font-size: 2rem;
   font-weight: 400;
   line-height: 1.2;
@@ -131,7 +85,7 @@
 
 /* H3 — Cormorant Garamond, 24px */
 .sl-markdown-content h3 {
-  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-family: 'Commit Mono', 'Courier New', monospace;
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.6;
@@ -168,7 +122,7 @@
 
 /* Page title (frontmatter title rendered by Starlight's PageTitle.astro) */
 h1#_top {
-  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-family: 'Commit Mono', 'Courier New', monospace;
   font-size: 3rem;
   font-weight: 400;
   line-height: 1.2;
@@ -177,9 +131,11 @@ h1#_top {
 /* Site title text */
 .site-title {
   color: #212121 !important;
-  font-family: 'Cormorant Garamond', Georgia, serif !important;
-  font-size: 2rem !important;
-  font-weight: 400 !important;
+  font-family: 'Commit Mono', 'Courier New', monospace !important;
+  font-size: 1.1rem !important;
+  font-weight: 700 !important;
+  text-transform: none !important;
+  letter-spacing: 0 !important;
 }
 
 :root[data-theme='dark'] .site-title {
@@ -245,7 +201,7 @@ h1#_top {
 :root[data-theme='dark'] .card:nth-child(4n + 3),
 :root[data-theme='dark'] .card:nth-child(4n + 4),
 :root[data-theme='dark'] .card:nth-child(4n + 5) {
-  --sl-card-border: #FFFFFF;
+  --sl-card-border: #CD5E20;
   --sl-card-bg:     transparent;
 }
 
@@ -254,7 +210,7 @@ h1#_top {
 .card:nth-child(4n + 3),
 .card:nth-child(4n + 4),
 .card:nth-child(4n + 5) {
-  --sl-card-border: #E0E0E0;
+  --sl-card-border: #CD5E20;
   --sl-card-bg:     #FFFFFF;
 }
 
@@ -341,25 +297,25 @@ button[data-open-modal] {
 /* Previous / Next pagination */
 .pagination-links a span,
 .pagination-links .link-title {
-  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-family: 'Commit Mono', 'Courier New', monospace;
   font-weight: 400;
 }
 
 /* "On this page" TOC heading */
 #starlight__on-this-page {
-  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-family: 'Commit Mono', 'Courier New', monospace;
   font-size: 1.3rem;
   font-weight: 400;
 }
 
 /* Sidebar group titles */
 .group-label .large {
-  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-family: 'Commit Mono', 'Courier New', monospace;
   font-size: 1.3rem;
   font-weight: 400;
 }
 
-/* Sidebar / UI labels — Commit Mono, 12px, +0.05em tracking */
+/* Sidebar / UI labels — Commit Mono, 12px, uppercase, +0.05em tracking */
 .sidebar-content,
 nav[aria-label] a,
 .sl-sidebar a,
@@ -368,4 +324,90 @@ nav[aria-label] a,
   font-size: 0.75rem;
   letter-spacing: 0.05em;
   line-height: 1.6;
+  text-transform: uppercase;
+}
+
+/* ─── Scanlines background — matches landing page ──────────────── */
+body {
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.015) 2px,
+    rgba(0, 0, 0, 0.015) 4px
+  );
+}
+
+:root[data-theme='dark'] body {
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(255, 255, 255, 0.02) 2px,
+    rgba(255, 255, 255, 0.02) 4px
+  );
+}
+
+/* ─── H4/H5/H6 — uppercase + tracking, matches landing page section headers */
+.sl-markdown-content h4,
+.sl-markdown-content h5,
+.sl-markdown-content h6 {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ─── Sidebar active item — orange left border ─────────────────── */
+.sl-sidebar a[aria-current='page'] {
+  border-left: 2px solid #CD5E20;
+  padding-left: calc(var(--sl-sidebar-item-padding-inline, 0.5rem) - 2px);
+  color: #CD5E20 !important;
+}
+
+/* ─── Table header — accent-tinted background ──────────────────── */
+.sl-markdown-content thead th {
+  background-color: hsl(22, 100%, 95%);
+  color: hsl(22, 73%, 26%);
+}
+
+:root[data-theme='dark'] .sl-markdown-content thead th {
+  background-color: hsl(22, 40%, 12%);
+  color: hsl(22, 100%, 89%);
+}
+
+/* ─── Search bar — orange border on focus ──────────────────────── */
+site-search dialog {
+  border: 1px solid #CD5E20 !important;
+}
+
+/* ─── Pagination — orange hover ────────────────────────────────── */
+.pagination-links a:hover {
+  border-color: #CD5E20 !important;
+  color: #CD5E20;
+}
+
+/* ─── Aside (note/tip) — sharp, no radius already handled ──────── */
+
+/* ─── "On this page" section label uppercase ───────────────────── */
+#starlight__on-this-page {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: 'Commit Mono', 'Courier New', monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+/* ─── TOC links — smaller, monospace, tracking ─────────────────── */
+.right-sidebar a {
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+/* ─── Section group labels — uppercase tracking ────────────────── */
+.group-label .large {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: 'Commit Mono', 'Courier New', monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -71,6 +71,26 @@ html, body {
   50%       { box-shadow: 0 0 8px 2px rgba(205, 94, 32, 0.5); }
 }
 
+.scanlines {
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.015) 2px,
+    rgba(0, 0, 0, 0.015) 4px
+  );
+}
+
+.dark .scanlines {
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(255, 255, 255, 0.02) 2px,
+    rgba(255, 255, 255, 0.02) 4px
+  );
+}
+
 .border-pulse {
   border-color: #CD5E20;
   animation: border-pulse 2.5s ease-in-out infinite;


### PR DESCRIPTION
…canlines

## Summary

- Removed Cormorant Garamond entirely from the documentation site; Commit Mono is now the sole font across all headings, body text, UI labels, and titles
- Removed Cormorant Garamond font preload from astro.config.mjs
- Added scanlines background texture to match the landing page aesthetic
- Sidebar active item now shows an orange (#CD5E20) left border and text colour
- Sidebar and section group labels are now uppercase with letter-spacing
- H4/H5/H6 headings are now uppercase with letter-spacing, consistent with landing page section headers
- "On this page" TOC label and right sidebar links converted to small uppercase monospace
- Table headers use orange-tinted muted background in light and dark mode
- Card borders on the Governance Solutions panel grid updated to orange (#CD5E20) in both themes
- Pagination links turn orange on hover
- Site title made larger and no longer forced uppercase

## Test plan
- [ ] All text across the docs renders in Commit Mono (no serif fallback visible)
- [ ] Scanlines visible on page background in both light and dark mode
- [ ] Active sidebar item highlighted in orange
- [ ] Welcome page card grid shows orange borders
- [ ] Table headers use orange-tinted background
- [ ] Site title "Powers Protocol" displays at correct size without uppercase
