### PR TITLE
documentation site mobile polish

### DIFF
--- a/documentation/src/styles/custom.css
+++ b/documentation/src/styles/custom.css
@@ -411,3 +411,64 @@ site-search dialog {
   font-size: 0.75rem;
   font-weight: 700;
 }
+
+/* ─── Mobile polish ─────────────────────────────────────────────── */
+@media (max-width: 50rem) {
+
+  /* Page title — scale down from 3rem */
+  h1#_top,
+  .sl-markdown-content h1 {
+    font-size: 1.6rem;
+    line-height: 1.3;
+  }
+
+  .sl-markdown-content h2 {
+    font-size: 1.25rem;
+    line-height: 1.3;
+  }
+
+  .sl-markdown-content h3 {
+    font-size: 1.05rem;
+    line-height: 1.4;
+  }
+
+  /* Body — slightly smaller so Commit Mono lines don't wrap as aggressively */
+  .sl-markdown-content p,
+  .sl-markdown-content li,
+  .sl-markdown-content td,
+  .sl-markdown-content th {
+    font-size: 0.875rem;
+    line-height: 1.7;
+  }
+
+  /* Code — smaller to prevent overflow */
+  .sl-markdown-content code,
+  .sl-markdown-content pre,
+  .sl-markdown-content pre code {
+    font-size: 0.75rem;
+  }
+
+  /* Content panel — remove border and cut padding on mobile */
+  .sl-markdown-content {
+    border: none;
+    padding: 0.75rem 0.25rem;
+  }
+
+  /* Tables — allow horizontal scroll rather than overflowing viewport */
+  .sl-markdown-content table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Pagination — stack vertically on narrow screens */
+  .pagination-links {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  /* Site title — slightly smaller on mobile */
+  .site-title {
+    font-size: 0.9rem !important;
+  }
+}


### PR DESCRIPTION
## Summary

- **Landing page redesign**: New sections (SectionApplications, SectionExamples, SectionForum), full mobile responsiveness pass, and visual polish throughout
- **Scroll arrows**: Clickable down-arrows at the end of every landing page section; turn orange (#CD5E20) on hover and smooth-scroll to the next section
- **Consistent section spacing**: Standardised top/bottom padding across all sections for balanced rhythm on both mobile and desktop
- **Copy improvements**: SectionIntro bullet points with orange dash style; bold closing statement; updated SectionExamples body text
- **Scanlines background**: Subtle horizontal texture on the landing page background matching the terminal aesthetic
- **Updated banner image**: optimistic_execution.png replaced with new version
- **Documentation site visual polish**: Commit Mono as the sole font (Cormorant Garamond removed), scanlines background, orange card borders on Governance Solutions grid, orange active sidebar item, uppercase tracking on labels and headings, accent-tinted table headers
- **Documentation mobile polish**: Responsive type scale (H1 3rem → 1.6rem, H2 2rem → 1.25rem), reduced body text size for Commit Mono readability, content panel border removed on mobile, horizontal-scrollable tables, stacked pagination
